### PR TITLE
Remember user by IP

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -24,7 +24,8 @@
         "std/path": "https://deno.land/std@0.200.0/path/mod.ts",
         "std/fs": "https://deno.land/std@0.200.0/fs/mod.ts",
         "zod": "https://esm.sh/zod@3.22.4",
-        "@trpc/server": "https://esm.sh/@trpc/server@10.45.0"
+        "@trpc/server": "https://esm.sh/@trpc/server@10.45.0",
+        "@trpc/client": "https://esm.sh/@trpc/client@10.45.0"
     },
     "compilerOptions": {
         "allowJs": true,

--- a/deno.json
+++ b/deno.json
@@ -28,7 +28,6 @@
         "@trpc/client": "https://esm.sh/@trpc/client@10.45.0"
     },
     "compilerOptions": {
-        "allowJs": true,
         "lib": [
             "deno.window",
             "deno.unstable",

--- a/server/trpc/context.ts
+++ b/server/trpc/context.ts
@@ -1,12 +1,16 @@
 import { DatabaseManager } from '../database/connection.ts';
+import type { Context as OakContext } from 'oak';
 
 export interface Context {
-    kv: Deno.Kv;
-    userId?: string;
-    roomId?: string;
+  db: typeof DatabaseManager;
+  ip: string;
+  userId?: string;
+  roomId?: string;
 }
 
-export function createContext(): Context {
-    const kv = DatabaseManager.getKv();
-    return { kv };
+export function createContext(ctx: OakContext): Context {
+  return {
+    db: DatabaseManager,
+    ip: ctx.request.ip,
+  };
 }

--- a/server/trpc/oak-adapter.ts
+++ b/server/trpc/oak-adapter.ts
@@ -1,1 +1,32 @@
- 
+import type { Context as OakContext } from 'oak';
+import type { AnyRouter } from '@trpc/server';
+import { fetchRequestHandler } from '@trpc/server/adapters/fetch';
+
+export function createOakTRPCHandler<TRouter extends AnyRouter>(
+  router: TRouter,
+  endpoint: string,
+  createContext: (ctx: OakContext) => any,
+) {
+  return async (ctx: OakContext) => {
+    const request = new Request(ctx.request.url, {
+      method: ctx.request.method,
+      headers: ctx.request.headers,
+      body: ctx.request.hasBody
+        ? ctx.request.body({ type: 'stream' }).value
+        : undefined,
+    });
+
+    const response = await fetchRequestHandler({
+      endpoint,
+      req: request,
+      router,
+      createContext: () => createContext(ctx),
+    });
+
+    ctx.response.status = response.status;
+    for (const [key, value] of response.headers.entries()) {
+      ctx.response.headers.set(key, value);
+    }
+    ctx.response.body = await response.text();
+  };
+}

--- a/server/trpc/oak-adapter.ts
+++ b/server/trpc/oak-adapter.ts
@@ -5,15 +5,13 @@ import { fetchRequestHandler } from '@trpc/server/adapters/fetch';
 export function createOakTRPCHandler<TRouter extends AnyRouter>(
   router: TRouter,
   endpoint: string,
-  createContext: (ctx: OakContext) => any,
+  createContext: (ctx: OakContext) => unknown,
 ) {
   return async (ctx: OakContext) => {
     const request = new Request(ctx.request.url, {
       method: ctx.request.method,
       headers: ctx.request.headers,
-      body: ctx.request.hasBody
-        ? ctx.request.body({ type: 'stream' }).value
-        : undefined,
+      body: ctx.request.hasBody ? ctx.request.body({ type: 'stream' }).value : undefined,
     });
 
     const response = await fetchRequestHandler({

--- a/www/pages/HomePage.tsx
+++ b/www/pages/HomePage.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import Layout from '../components/Layout.tsx';
 import { roomAPI } from '../services/api.ts';
@@ -6,6 +6,21 @@ import { roomAPI } from '../services/api.ts';
 function HomePage() {
     const navigate = useNavigate();
     const [isJoining, setIsJoining] = useState(false);
+
+    useEffect(() => {
+        async function checkUser() {
+            const res = await roomAPI.getCurrentUser();
+            if (res.success && res.data) {
+                const { userId, roomId, username } = res.data;
+                localStorage.setItem(
+                    'syncwatch-user',
+                    JSON.stringify({ roomId, userId, username })
+                );
+                navigate(`/room/${roomId}`);
+            }
+        }
+        checkUser();
+    }, []);
 
     const handleJoinRoom = async (e: React.FormEvent<HTMLFormElement>) => {
         e.preventDefault();

--- a/www/services/api.ts
+++ b/www/services/api.ts
@@ -14,9 +14,9 @@ interface JoinRoomResponse {
       id: string;
       name: string;
       owner_id: string;
-      current_video: any;
-      queue: any[];
-      users: any[];
+      current_video: unknown;
+      queue: unknown[];
+      users: unknown[];
       users_count: number;
     };
   };


### PR DESCRIPTION
## Summary
- generate deterministic user ID from IP using UUID v5
- store/retrieve user info in DB keyed by IP
- add API endpoint to fetch current user
- auto-join existing user in HomePage
- switch communication layer to tRPC

## Testing
- `deno fmt` *(fails: command not found)*
- `deno lint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858dd3c5f1c8330bdd58f00fe6acb78