### PR TITLE
Fix trunk build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ sqlx = { version = "0.7", features = ["runtime-tokio-rustls", "sqlite", "chrono"
 # sqlx = { version = "0.7", features = ["runtime-tokio-native-tls", "sqlite", "chrono", "uuid"], optional = true }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-uuid = { version = "1", features = ["v4", "serde"] }
+uuid = { version = "1", features = ["v4", "serde", "js"] }
 chrono = { version = "0.4", features = ["serde"] }
 reqwest = { version = "0.11", features = ["json", "rustls-tls"], default-features = false, optional = true }
 dotenv = { version = "0.15", optional = true }

--- a/index.html
+++ b/index.html
@@ -24,6 +24,7 @@
         <script src="https://www.youtube.com/iframe_api" async></script>
 
         <!-- Trunk will inject the WASM module and other assets here -->
+        <link data-trunk rel="rust" data-target-name="youtube-together" />
     </head>
 
     <body class="bg-gray-900 text-white">


### PR DESCRIPTION
## Summary
- allow building for wasm by enabling `js` feature of uuid
- specify the correct binary for Trunk in `index.html`
- run `trunk build --release` successfully

## Testing
- `trunk build --release`

------
https://chatgpt.com/codex/tasks/task_e_685a64161034833092ffa3159f39b496