### PR TITLE
Build server with futures dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3967,6 +3967,7 @@ dependencies = [
  "console_error_panic_hook",
  "console_log",
  "dotenv",
+ "futures",
  "gloo-timers",
  "leptos",
  "leptos_axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ web-sys = { version = "0.3", features = [
     "MessageEvent",
 ] }
 gloo-timers = { version = "0.3", features = ["futures"] }
+futures = "0.3"
 
 [features]
 hydrate = ["leptos/hydrate", "leptos_meta/hydrate", "leptos_router/hydrate"]


### PR DESCRIPTION
## Summary
- add `futures` crate dependency to fix missing import when building the server

## Testing
- `cargo build --release --bin server --features ssr`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_685a6cba60d88330ad9d99a6ccc818c0