### PR TITLE
Fix first-time join 401

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3163,6 +3163,10 @@ version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
 dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project",
+ "pin-project-lite",
  "tower-layer",
  "tower-service",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ leptos_axum = { version = "0.6", optional = true }
 # Server-side dependencies
 axum = { version = "0.7", optional = true }
 tokio = { version = "1", features = ["full"], optional = true }
-tower = { version = "0.4", optional = true }
+tower = { version = "0.4", optional = true, features = ["util"] }
 tower-http = { version = "0.5", features = ["fs"], optional = true }
 sqlx = { version = "0.7", features = ["runtime-tokio-rustls", "sqlite", "chrono", "uuid"], optional = true }
 # Alternative for systems without OpenSSL development headers:

--- a/src/server/auth.rs
+++ b/src/server/auth.rs
@@ -3,6 +3,11 @@ use axum::{body::Body, http::Request, http::StatusCode, middleware::Next, respon
 /// Simple authentication middleware that expects an `X-Auth-Token` header.
 /// The header value is inserted into request extensions for handlers to use.
 pub async fn auth(mut req: Request<Body>, next: Next) -> Result<Response, StatusCode> {
+    // Allow unauthenticated access to join_room so new users can register
+    if req.uri().path() == "/api/join_room" {
+        return Ok(next.run(req).await);
+    }
+
     let token = req
         .headers()
         .get("x-auth-token")

--- a/tests/auth.rs
+++ b/tests/auth.rs
@@ -1,0 +1,33 @@
+use axum::{Router, routing::get, http::{Request, StatusCode}, body::Body};
+use tower::ServiceExt;
+use youtube_together::server::auth::auth;
+
+async fn ok_handler() -> &'static str { "ok" }
+
+#[tokio::test]
+async fn allow_join_room_without_token() {
+    let app = Router::new()
+        .route("/api/join_room", get(ok_handler))
+        .layer(axum::middleware::from_fn(auth));
+
+    let res = app
+        .oneshot(Request::builder().uri("/api/join_room").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn reject_other_paths_without_token() {
+    let app = Router::new()
+        .route("/api/other", get(ok_handler))
+        .layer(axum::middleware::from_fn(auth));
+
+    let res = app
+        .oneshot(Request::builder().uri("/api/other").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
+}


### PR DESCRIPTION
## Summary
- allow `/api/join_room` requests through auth middleware
- add tests covering auth bypass for join_room
- enable Tower `util` feature for tests

## Testing
- `cargo test --features ssr -- --nocapture`


------
https://chatgpt.com/codex/tasks/task_e_685ad8d897f883309c12335fde911d3c